### PR TITLE
Initial Version of AWS Orgs Support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,6 +41,15 @@
             "args": ["--ipaddr=52.4.175.237", "--verbose"]
         },
         {
+            "name": "Launch - IP Param - Test IP - ALB - Organizations",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "main.go",
+            "env": {"AWS_REGION": "us-east-1"},
+            "args": ["--ipaddr=52.4.175.237", "--org-search", "--verbose"]
+        },
+        {
             "name": "Launch - IP Param - Test IP - ALB - Silent Output",
             "type": "go",
             "request": "launch",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/magneticstain/ip-2-cloudresource
 go 1.19
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.20.1
+	github.com/aws/aws-sdk-go-v2 v1.20.3
 	github.com/aws/aws-sdk-go-v2/config v1.18.33
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.112.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.16.2
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/service/organizations v1.20.4 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
 )
@@ -19,14 +20,14 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.32 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.8 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.38 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.32 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.40 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.39 // indirect
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.28.2
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.32 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.13.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.21.2 // indirect
-	github.com/aws/smithy-go v1.14.1 // indirect
+	github.com/aws/smithy-go v1.14.2 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go-v2 v1.20.1 h1:rZBf5DWr7YGrnlTK4kgDQGn1ltqOg5orCYb/UhOFZkg=
 github.com/aws/aws-sdk-go-v2 v1.20.1/go.mod h1:NU06lETsFm8fUC6ZjhgDpVBcGZTFQ6XM+LZWZxMI4ac=
+github.com/aws/aws-sdk-go-v2 v1.20.3 h1:lgeKmAZhlj1JqN43bogrM75spIvYnRxqTAh1iupu1yE=
+github.com/aws/aws-sdk-go-v2 v1.20.3/go.mod h1:/RfNgGmRxI+iFOB1OeJUyxiU+9s88k3pfHvDagGEp0M=
 github.com/aws/aws-sdk-go-v2/config v1.18.33 h1:JKcw5SFxFW/rpM4mOPjv0VQ11E2kxW13F3exWOy7VZU=
 github.com/aws/aws-sdk-go-v2/config v1.18.33/go.mod h1:hXO/l9pgY3K5oZJldamP0pbZHdPqqk+4/maa7DSD3cA=
 github.com/aws/aws-sdk-go-v2/credentials v1.13.32 h1:lIH1eKPcCY1ylR4B6PkBGRWMHO3aVenOKJHWiS4/G2w=
@@ -8,8 +10,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.8 h1:DK/9C+UN/X+1+Wm8pqaDksQ
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.8/go.mod h1:ce7BgLQfYr5hQFdy67oX2svto3ufGtm6oBvmsHScI1Q=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.38 h1:c8ed/T9T2K5I+h/JzmF5tpI46+OODQ74dzmdo+QnaMg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.38/go.mod h1:qggunOChCMu9ZF/UkAfhTz25+U2rLVb3ya0Ua6TTfCA=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.40 h1:CXceCS9BrDInRc74GDCQ8Qyk/Gp9VLdK+Rlve+zELSE=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.40/go.mod h1:5kKmFhLeOVy6pwPDpDNA6/hK/d6URC98pqDDqHgdBx4=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.32 h1:hNeAAymUY5gu11WrrmFb3CVIp9Dar9hbo44yzzcQpzA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.32/go.mod h1:0ZXSqrty4FtQ7p8TEuRde/SZm9X05KT18LAUlR40Ln0=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.34 h1:B+nZtd22cbko5+793hg7LEaTeLMiZwlgCLUrN5Y0uzg=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.34/go.mod h1:RZP0scceAyhMIQ9JvFp7HvkpcgqjL4l/4C+7RAeGbuM=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.39 h1:fc0ukRAiP1syoSGZYu+DaE+FulSYhTiJ8WpVu5jElU4=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.39/go.mod h1:WLAW8PT7+JhjZfLSWe7WEJaJu0GNo0cKc2Zyo003RBs=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.28.2 h1:1w4jdi9qEq2kBT0C/QSM9mgwuD3TzdZlf6eUMUg5y2M=
@@ -22,6 +28,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.21.0 h1:lSCNS+ZMz
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.21.0/go.mod h1:AZv/T0/2rhNBLiY2k109TT6HJ7Z0P8Z+SYvs0jqVkXE=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.32 h1:dGAseBFEYxth10V23b5e2mAS+tX7oVbfYHD6dnDdAsg=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.32/go.mod h1:4jwAWKEkCR0anWk5+1RbfSg1R5Gzld7NLiuaq5bTR/Y=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.20.4 h1:fYzNnGtOYUVHVIIObXb/SKHsAk8BkC5UuRMISiHgJv4=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.20.4/go.mod h1:NFt93EG6FYSDkX0Ay0W5Sv7bneQXJKOzH4FoNQzYpZs=
 github.com/aws/aws-sdk-go-v2/service/sso v1.13.2 h1:A2RlEMo4SJSwbNoUUgkxTAEMduAy/8wG3eB2b2lP4gY=
 github.com/aws/aws-sdk-go-v2/service/sso v1.13.2/go.mod h1:ju+nNXUunfIFamXUIZQiICjnO/TPlOmWcYhZcSy7xaE=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.2 h1:OJELEgyaT2kmaBGZ+myyZbTTLobfe3ox3FSh5eYK9Qs=
@@ -30,6 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.21.2 h1:ympg1+Lnq33XLhcK/xTG4yZHPs1O
 github.com/aws/aws-sdk-go-v2/service/sts v1.21.2/go.mod h1:FQ/DQcOfESELfJi5ED+IPPAjI5xC6nxtSolVVB773jM=
 github.com/aws/smithy-go v1.14.1 h1:EFKMUmH/iHMqLiwoEDx2rRjRQpI1YCn5jTysoaDujFs=
 github.com/aws/smithy-go v1.14.1/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.14.2 h1:MJU9hqBGbvWZdApzpvoF2WAIJDbtjK2NDJSiJP7HblQ=
+github.com/aws/smithy-go v1.14.2/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ func main() {
 	cloudSvc := flag.String("svc", "all", "Specific cloud service to search")
 	ipFuzzing := flag.Bool("ip-fuzzing", true, "Toggle the IP fuzzing feature to evaluate the IP and help optimize search (not recommended for small accounts)")
 	advIpFuzzing := flag.Bool("adv-ip-fuzzing", true, "Toggle the advanced IP fuzzing feature to perform a more intensive heuristics evaluation to fuzz the service (not recommended for IPv6 addresses)")
+	orgSearch := flag.Bool("org-search", false, "Search through all child accounts of the organization for resources, as well as target account (target account should be parent account)")
+	orgSearchRoleName := flag.String("org-search-role-name", "ip2cr", "The name of the role in each child account of an AWS Organization to assume when performing a search")
 	jsonOutput := flag.Bool("json", false, "Outputs results in JSON format; implies usage of --silent flag")
 	verboseOutput := flag.Bool("verbose", false, "Outputs all logs, from debug level to critical")
 	flag.Parse()
@@ -44,7 +46,7 @@ func main() {
 
 	log.Info("searching for IP ", *ipAddr, " in ", *cloudSvc, " service(s)")
 	searchCtlr := search.NewSearch(&ac)
-	matchedResource, err := searchCtlr.StartSearch(ipAddr, *ipFuzzing, *advIpFuzzing)
+	matchedResource, err := searchCtlr.StartSearch(ipAddr, *ipFuzzing, *advIpFuzzing, *orgSearch, *orgSearchRoleName)
 	if err != nil {
 		log.Fatal("failed to run search :: [ ERR: ", err, " ]")
 	}

--- a/src/aws_connector/aws_connector.go
+++ b/src/aws_connector/aws_connector.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 type AWSConnector struct {
@@ -12,15 +14,36 @@ type AWSConnector struct {
 }
 
 func New() (AWSConnector, error) {
-	cfg, err := ConnectToAWS()
+	cfg, err := ConnectToAWS(nil)
 
 	ac := AWSConnector{AwsConfig: cfg}
 
 	return ac, err
 }
 
-func ConnectToAWS() (aws.Config, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+func NewAWSConnectorAssumeRole(roleArn *string) (AWSConnector, error) {
+	cfg, err := ConnectToAWS(roleArn)
 
-	return cfg, err
+	ac := AWSConnector{AwsConfig: cfg}
+
+	return ac, err
+}
+
+func ConnectToAWS(roleArn *string) (aws.Config, error) {
+	var cfg aws.Config
+
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return cfg, err
+	}
+
+	if roleArn != nil {
+		// assume role and override cfg creds with sts creds
+		// REF: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/credentials/stscreds
+		stsSvc := sts.NewFromConfig(cfg)
+		roleCreds := stscreds.NewAssumeRoleProvider(stsSvc, *roleArn)
+		cfg.Credentials = aws.NewCredentialsCache(roleCreds)
+	}
+
+	return cfg, nil
 }

--- a/src/plugin/organizations/organizations.go
+++ b/src/plugin/organizations/organizations.go
@@ -1,0 +1,40 @@
+package organizations
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
+
+	awsconnector "github.com/magneticstain/ip-2-cloudresource/src/aws_connector"
+	generalPlugin "github.com/magneticstain/ip-2-cloudresource/src/plugin"
+)
+
+type OrganizationsPlugin struct {
+	GenPlugin *generalPlugin.Plugin
+	AwsConn   awsconnector.AWSConnector
+}
+
+func NewOrganizationsPlugin(aws_conn *awsconnector.AWSConnector) OrganizationsPlugin {
+	orgp := OrganizationsPlugin{GenPlugin: &generalPlugin.Plugin{}, AwsConn: *aws_conn}
+
+	return orgp
+}
+
+func (orgp OrganizationsPlugin) GetResources() (*[]types.Account, error) {
+	var orgAccts []types.Account
+
+	orgClient := organizations.NewFromConfig(orgp.AwsConn.AwsConfig)
+	paginator := organizations.NewListAccountsPaginator(orgClient, &organizations.ListAccountsInput{})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return &orgAccts, err
+		}
+
+		orgAccts = append(orgAccts, output.Accounts...)
+	}
+
+	return &orgAccts, nil
+}

--- a/src/search/search_test.go
+++ b/src/search/search_test.go
@@ -107,7 +107,7 @@ func TestStartSearch_NoFuzzing(t *testing.T) {
 		testName := td.ipAddr
 
 		t.Run(testName, func(t *testing.T) {
-			res, _ := search.StartSearch(&td.ipAddr, false, false)
+			res, _ := search.StartSearch(&td.ipAddr, false, false, false, "")
 
 			matchedResourceType := reflect.TypeOf(res)
 			expectedType := "Resource"
@@ -127,7 +127,7 @@ func TestStartSearch_BasicFuzzing(t *testing.T) {
 		testName := td.ipAddr
 
 		t.Run(testName, func(t *testing.T) {
-			res, _ := search.StartSearch(&td.ipAddr, true, false)
+			res, _ := search.StartSearch(&td.ipAddr, true, false, false, "")
 
 			matchedResourceType := reflect.TypeOf(res)
 			expectedType := "Resource"
@@ -147,7 +147,7 @@ func TestStartSearch_AdvancedFuzzing(t *testing.T) {
 		testName := td.ipAddr
 
 		t.Run(testName, func(t *testing.T) {
-			res, _ := search.StartSearch(&td.ipAddr, true, false)
+			res, _ := search.StartSearch(&td.ipAddr, true, false, false, "")
 
 			matchedResourceType := reflect.TypeOf(res)
 			expectedType := "Resource"


### PR DESCRIPTION
The feature works by first checking if aws orgs search is requested. If so, it fetches all account IDs in the org, traverses through each one, generates sts creds for a target role in that account, and then uses that to try to run the search.

Resolves #51 , Resolves #52 