### PR TITLE
Issue 346 update ip addr cli param to required

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/rollbar/rollbar-go"
@@ -122,6 +123,11 @@ func main() {
 	networkMapping := flag.Bool("network-mapping", false, "If enabled, generate a network map associated with the identified resource if it's found (default: false)")
 
 	flag.Parse()
+
+	if *ipAddr == "" {
+		log.Error("IP address is required")
+		os.Exit(1)
+	}
 
 	if *version {
 		fmt.Println("ip-2-cloudresource", APP_VER)

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 	verboseOutput := flag.Bool("verbose", false, "Outputs all logs, from debug level to critical (default: false)")
 
 	// base
-	ipAddr := flag.String("ipaddr", "127.0.0.1", "IP address to search for (default: 127.0.0.1)")
+	ipAddr := flag.String("ipaddr", "", "IP address to search for (default: 127.0.0.1)")
 	cloudSvc := flag.String("svc", "all", "Specific cloud service(s) to search. Multiple services can be listed in CSV format, e.g. elbv1,elbv2. Available services are: [all, cloudfront , ec2 , elbv1 , elbv2]  (default: all)")
 
 	// FEATURE FLAGS


### PR DESCRIPTION
# PR Summary

Update `--ip-addr` CLI parameter to be required. If the CLI parameter isn't supplied, or a blank string is supplied for it, IP2CR will print an error and exit 1.

## Related Issue(s)

Related to #346 
