### PR TITLE
Add Github Actions Workflow For Container Publish

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,47 @@
+# REF: https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-docker-hub-and-github-packages
+
+name: Publish Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registries:
+    name: Push Docker image to multiple registries
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            magneticstain/ip-2-cloudresource
+            ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:alpine3.19
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+RUN go build -o ./ip2cr
+
+ENTRYPOINT [ "./ip2cr" ]
+CMD [ "--help" ]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The most portable way to install and run IP2CR is by using Docker. Check out the
 ```bash
 git clone https://github.com/magneticstain/ip-2-cloudresource.git
 docker build -t ip2cr .
-docker run --name=ip-2-cloudresource ip2cr
+docker run --rm --name=ip-2-cloudresource ip2cr
 ```
 
 ### Homebrew

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ IP-2-CloudResource (IP2CR) is a tool used for correlating a cloud IP address wit
 
 #### 2024
 
-- [ ] Docker Support ( [Issue #367](https://github.com/magneticstain/ip-2-cloudresource/issues/367) )
+- [X] Docker Support ( [Issue #367](https://github.com/magneticstain/ip-2-cloudresource/issues/367) )
 - [ ] GCP Support ( [Issue #361](https://github.com/magneticstain/ip-2-cloudresource/issues/361) )
 - [ ] Azure Support ( [Issue #362](https://github.com/magneticstain/ip-2-cloudresource/issues/362) )
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ IP2CR supports running on n-1 minor versions of Golang, aka [stable and old-stab
 
 ## Install
 
+### Docker
+
+The most portable way to install and run IP2CR is by using Docker. Check out the `main` branch of this repo, build the IP2CR image, and run it.
+
+```bash
+git clone https://github.com/magneticstain/ip-2-cloudresource.git
+docker build -t ip2cr .
+docker run --name=ip-2-cloudresource ip2cr
+```
+
 ### Homebrew
 
 The easiest way to install IP2CR if you're using Mac OS is to use [Homebrew](https://brew.sh). With homebrew installed, run the following to install IP2CR:


### PR DESCRIPTION
# PR Summary
Add a manifest for a Github Actions workflow that will automatically upload a container image of IP2CR after each release to both Docker Hub and GHCR.

## Related Issue(s)

Related to #367 
